### PR TITLE
Added standard write method for output.

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -157,7 +157,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  string  $string
 	 * @return void
 	 */
-	protected function write($string)
+	protected function line($string)
 	{
 		$this->output->writeln($string);
 	}


### PR DESCRIPTION
Noticed that you couldn't write just normal output without having to use the ugly `$this->output->writeln()` method. This adds the much nicer `$this->write()` alias.
