### PR TITLE
Improving the performance of a command running inside the Scheduler

### DIFF
--- a/Scheduling/CommandBuilder.php
+++ b/Scheduling/CommandBuilder.php
@@ -49,8 +49,12 @@ class CommandBuilder
 
         $redirect = $event->shouldAppendOutput ? ' >> ' : ' > ';
 
-        $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
-
+        $finished = '';
+        
+        if ($event->hasAfterCallbacks()) {
+            $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
+        }
+        
         return $this->ensureCorrectUser($event,
             '('.$event->command.$redirect.$output.' 2>&1 '.(windows_os() ? '&' : ';').' '.$finished.') > '
             .ProcessUtils::escapeArgument($event->getDefaultOutput()).' 2>&1 &'

--- a/Scheduling/Event.php
+++ b/Scheduling/Event.php
@@ -818,6 +818,6 @@ class Event
      */
     public function hasAfterCallbacks()
     {
-      return !empty($afterCallbacks);
+      return !empty($this->afterCallbacks);
     }
 }

--- a/Scheduling/Event.php
+++ b/Scheduling/Event.php
@@ -810,4 +810,14 @@ class Event
 
         return $this;
     }
+    
+    /**
+     * Determine if there is any callback to run after
+     *
+     * @return bool
+     */
+    public function hasAfterCallbacks()
+    {
+      return !empty($afterCallbacks);
+    }
 }


### PR DESCRIPTION
I think we don't need to run the command schedule:finish when we don't have any after callback function in the event. the performance will be better.  we will spend less CPU and the load will be lower. 
Let me know if I'm wrong 
